### PR TITLE
Fixed incorrect replacement of constants in template definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,19 +138,33 @@ and be usable as-is.  Because they are packages, if you aren't writing
 a public template you should put them in a subdirectory of your
 project most likely.
 
-To make a Go package a template it should have a type definition and a
-special comment signaling to `gotemplate` what the type is called and
-what its type parameters are.
+To make a Go package a template it should have one or more declarations
+and a special comment signaling to `gotemplate` what the template is 
+called and what its parameters are. Currently, supported parameterized
+declarations are type, const, and func.  
 
 Here is an example from the set package.
 
     // template type Set(A)
     type A int
 
-This indicates that the type is called `Set` and it has 1 type
+This indicates that the template is called `Set` and it has 1 type
 parameter `A`.  When you are writing the template package make sure
 you use `A` instead of `int` where you want it to be substituted with
 a new type when the template is instantiated.
+
+Similarly, you could write a package with a const parameter.
+
+    // template type Vector(A, n)
+    type A int
+    const n = 2
+
+    type Vector[n]A
+
+This indicates that the template is called `Vector` and it has 1 type 
+parameter `A` and one constant parameter `n`. Again, all uses of `n` 
+in the template code will be replaced by a literal value when the template
+is instantiated.
 
 All the definitions of the template parameters will be removed from
 the instantiated template.

--- a/template.go
+++ b/template.go
@@ -210,13 +210,37 @@ func (t *template) parse(inputFile string) {
 			case token.IMPORT:
 				// Ignore imports
 			case token.CONST, token.VAR:
-				for _, spec := range d.Specs {
+				// Find and remove identifiers found in template
+				// params
+				emptySpecs := []int{}
+				for i, spec := range d.Specs {
+					namesToRemove := []int{}
 					v := spec.(*ast.ValueSpec)
-					for _, name := range v.Names {
+					for j, name := range v.Names {
 						debugf("VAR or CONST %v", name.Name)
 						namesToMangle = append(namesToMangle, name.Name)
+						if containsString(name.Name, t.templateArgs) {
+							namesToRemove = append(namesToRemove, j)
+						}
+					}
+					// Shuffle the removed names out of v.Names and v.Values
+					for i := len(namesToRemove) - 1; i >= 0; i-- {
+						p := namesToRemove[i]
+						v.Names = append(v.Names[:p], v.Names[p+1:]...)
+						v.Values = append(v.Values[:p], v.Values[p+1:]...)
+					}
+					// Write it back again
+					d.Specs[i] = v
+					if len(v.Names) == 0 {
+						emptySpecs = append(emptySpecs, i)
 					}
 				}
+				// Remove now-empty specs
+				for i := len(emptySpecs) - 1; i >= 0; i-- {
+					p := emptySpecs[i]
+					d.Specs = append(d.Specs[:p], d.Specs[p+1:]...)
+				}
+				remove = len(d.Specs) == 0
 			case token.TYPE:
 				if len(d.Specs) != 1 {
 					fatalf("Unexpected specs on TYPE")

--- a/template_test.go
+++ b/template_test.go
@@ -133,6 +133,81 @@ func Minone(a int8) int8 {
 }
 `,
 	},
+	{
+		title: "Simple Test constants",
+		args:  "Vector2(float32, 2)",
+		pkg:   "main",
+		in: `package tt
+
+// template type Vector(A, n)
+type A float32
+const n = 3
+
+type Vector [n]A
+
+func (v Vector) Add(b Vector) {
+	for i := range v {
+		v += b[i]
+	}
+}
+`,
+		outName: "gotemplate_Vector2.go",
+		out: `package main
+
+// template type Vector(A, n)
+
+type Vector2 [2]float32
+
+func (v Vector2) Add(b Vector2) {
+	for i := range v {
+		v += b[i]
+	}
+}
+`,
+	},
+	{
+		title: "Test constants",
+		args:  "Matrix22(float32, 2, 2)",
+		pkg:   "main",
+		in: `package mat
+
+// template type Matrix(A, n, m)
+type A float32
+
+const (
+	n, a, b, m = 1, 2, 3, 1
+)
+
+type Matrix [n][m]A
+
+func (mat Matrix) Add(x Matrix) {
+	for i := range mat {
+		for j := range mat[i] {
+			mat[i][j] += x[i][j]
+		}
+	}
+}
+`,
+		outName: "gotemplate_Matrix22.go",
+		out: `package main
+
+// template type Matrix(A, n, m)
+
+const (
+	aMatrix22, bMatrix22 = 2, 3
+)
+
+type Matrix22 [2][2]float32
+
+func (mat Matrix22) Add(x Matrix22) {
+	for i := range mat {
+		for j := range mat[i] {
+			mat[i][j] += x[i][j]
+		}
+	}
+}
+`,
+	},
 }
 
 func testTemplate(t *testing.T, test *TestTemplate) {


### PR DESCRIPTION
I'm interested in using gotemplate to generate math libraries. I figured that using a constant as a template parameter would be the natural way to go about that. See my example:

``` Go
package tt

// template type Vector(A, n)
type A float32
const n = 2

type Vector [n]A

func (v *Vector) Add(b Vector) {
    for i := range v {
        v[i] += b[i]
    }
}
```

Currently, if I instantiate this template with the argument `Vector3(float32, 3)`, I get `const 3 = 3` where the const declaration is. This patch fixes that behavior and allows using constants in the template parameters. It does not validate any constraints, e.g. a const parameter must be a literal value, etc. There is still more work to do to support Math libraries but this is a step closer, and one I think is fairly agreeable. Other decisions will need more careful consideration.
